### PR TITLE
Listen on all interfaces plus small fixes.

### DIFF
--- a/jobs/vault/spec
+++ b/jobs/vault/spec
@@ -10,10 +10,9 @@ templates:
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
   config/vault.conf.erb:  config/server.hcl
 properties:
-
   vault.listener.tcp.address:
     description: Address for TCP connection
-    default: 127.0.0.1
+    default: 0.0.0.0
   vault.listener.tcp.port:
     description: Port for TCP connection
     default: 8200

--- a/templates/infrastructure-aws-ec2.yml
+++ b/templates/infrastructure-aws-ec2.yml
@@ -3,7 +3,7 @@ meta:
   persistent_disk: 4096
 
   stemcell:
-    name: bosh-aws-xen-ubuntu
+    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
     version: latest
 
 jobs:
@@ -15,18 +15,11 @@ jobs:
 
 compilation:
   cloud_properties:
-    instance_type: m1.small
+    instance_type: m3.medium
 
 resource_pools:
   - name: small_z1
     cloud_properties:
       instance_type: m1.small
 
-networks:
-  - name: floating
-    type: vip
-    cloud_properties: {}
-  - name: vault1
-    type: dynamic
-    cloud_properties:
-      security_groups: (( meta.security_groups ))
+networks: (( merge ))

--- a/templates/jobs.yml
+++ b/templates/jobs.yml
@@ -17,8 +17,7 @@ jobs:
     resource_pool: small_z1
     networks: (( merge ))
     persistent_disk: 0
-    properties: {}
-
+    properties: (( merge ))
 
 networks: (( merge ))
 

--- a/templates/make_manifest
+++ b/templates/make_manifest
@@ -29,7 +29,8 @@ if [[ $DIRECTOR_NAME = "warden" ]]; then
 fi
 
 if [[ $infrastructure = "aws-ec2" ]]; then
-  if [[ $DIRECTOR_CPI != "aws" ]]; then
+  if [[ $DIRECTOR_CPI != "cpi" ]]; then
+    DIRECTOR_CPI='aws'
     echo "Not targeting an AWS BOSH. Please use 'bosh target' before running this script."
     exit 1
   fi


### PR DESCRIPTION
- Listen on all interfaces. 
- Larger compilation VM on EC2. 
- Update stemcell. 
- Fix CPI detection for AWS.

Vault was only listening on the loopback interface which made it unreachable from other hosts.
