### PR TITLE
Add vault.ha.* properties for HA Vault

### DIFF
--- a/jobs/vault/spec
+++ b/jobs/vault/spec
@@ -24,6 +24,12 @@ properties:
   vault.listener.tcp.tls.key:
     description: Contents of the PEM-encoded TLS server private key
 
+  vault.ha.name:
+    description: "The DNS hostname to advertise in HA configuration.  The keywords (deployment) and (index) will be replaced by the configured deployment and instance index (i.e. 'prod-vault' and '3')"
+    default: "(deployment)-(index)"
+  vault.ha.domain:
+    description: "The DNS domain name to advertise in HA configuration.  If unspecified, advertise_addr will not be set."
+
   vault.disable_mlock:
     description: Disable mlock if you're crazy
     default: false

--- a/jobs/vault/templates/config/vault.conf.erb
+++ b/jobs/vault/templates/config/vault.conf.erb
@@ -1,6 +1,26 @@
 <% if p("vault.disable_mlock") == true %>disable_mlock = true<% end %>
 <% if p("vault.statsite_addr", "").empty? == false %>statsite_addr = <%= p("vault.statsite_addr") %><% end %>
 <% if p("vault.statsd_addr", "").empty? == false %>statsd_addr = <%= p("vault.statsd_addr") %><% end %>
+<%
+  tls = false
+  schema = "http"
+  if_p("vault.listener.tcp.tls.certificate", "") do |cert|
+    if_p("vault.listener.tcp.tls.key", "") do |key|
+      if cert != "" and key != ""
+        tls = true
+        schema = "https"
+      end
+    end
+  end
+%>
+<%
+  advertise_addr=""
+  unless p("vault.ha.domain","").empty?
+    hostname = p("vault.ha.name").gsub('(deployment)', spec.deployment.to_s)
+                                 .gsub('(index)',      spec.index.to_s)
+    advertise_addr = "advertise_addr = \"#{schema}://#{hostname}.#{p("vault.ha.domain")}:#{p("vault.listener.tcp.port")}\""
+  end
+%>
 <% if p("vault.backend.use_consul", "false") == true %>
 backend "consul"{
   path = "<%= p("vault.backend.consul.path") %>"
@@ -8,11 +28,13 @@ backend "consul"{
   <% if p("vault.backend.consul.scheme", "").empty? == false %>scheme = "<%= p("vault.backend.consul.scheme") %>"<% end %>
   <% if p("vault.backend.consul.datacenter", "").empty? == false %>datacenter = "<%= p("vault.backend.consul.datacenter") %>"<% end %>
   <% if p("vault.backend.consul.token", "").empty? == false %>token = "<%= p("vault.backend.consul.token") %>"<% end %>
+  <%= advertise_addr %>
 }
 <% elsif p("vault.backend.use_zookeeper", "false") == true %>
 backend "zookeeper" {
   address = "<%= p("vault.backend.zookeeper.address") %>"
   path = "<%= p("vault.backend.zookeeper.path") %>"
+  <%= advertise_addr %>
 }
 <% elsif p("vault.backend.use_file", "false") == true %>
 backend "file" {
@@ -26,21 +48,12 @@ backend "s3" {
   region = "<%= p('vault.backend.s3.region') %>"
   <% if p("vault.backend.s3.endpoint", "").empty? == false %>endpoint = "<%= p('vault.backend.s3.endpoint') %>"<% end %>
   <% if p("vault.backend.s3.session_token", "").empty? == false %>session_token = "<%= p('vault.backend.s3.session_token') %>"<% end %>
+  <%= advertise_addr %>
 }
 <% else %>
 backend "inmem" {
 }
 <% end %>
-<%
-  tls = false
-  if_p("vault.listener.tcp.tls.certificate", "") do |cert|
-    if_p("vault.listener.tcp.tls.key", "") do |key|
-      if cert != "" and key != ""
-        tls = true
-      end
-    end
-  end
-%>
 listener "tcp" {
  address = "<%= p("vault.listener.tcp.address") %>:<%= p("vault.listener.tcp.port") %>"
  <% if !tls %>tls_disable = 1<% end %>


### PR DESCRIPTION
- vault.ha.name specifies the hostname portion of the advertised FQDN
  (for non-leader -> leader handoff redirection)
- vault.ha.domain specifies the domain portion of the advertised FQDN

This should be enough to support HA (with an HA-friendly backend like
Consul), assuming you can set up a single SSL/TLS certificate as a
wildcard, or with subjectAltNames for all individually named components.
