### PR TITLE
Enable mutual auth between vault and consul backend

### DIFF
--- a/jobs/vault/spec
+++ b/jobs/vault/spec
@@ -11,6 +11,9 @@ templates:
   config/vault.conf.erb:  config/server.hcl
   ssl/certificate.pem: ssl/certificate.pem
   ssl/key.pem: ssl/key.pem
+  ssl/ca_certificate.pem: ssl/ca_certificate.pem
+  ssl/consul_certificate.pem: ssl/consul_certificate.pem
+  ssl/consul_key.pem: ssl/consul_key.pem
 properties:
   vault.listener.tcp.address:
     description: Address for TCP connection
@@ -23,12 +26,29 @@ properties:
     description: Contents of the PEM-encoded TLS server certificate
   vault.listener.tcp.tls.key:
     description: Contents of the PEM-encoded TLS server private key
+  vault.listener.tcp.tls.min_version:
+    description: Minimum TLS version to use
+    default: "tls12"
+
+  vault.listener.cluster.address:
+    description: Address to bind to for cluster server-to-server requests
+    default: 0.0.0.0
+  vault.listener.cluster.port:
+    description: Port for cluster address required for server-to-server connection
+    default: 8201
 
   vault.ha.name:
     description: "The DNS hostname to advertise in HA configuration.  The keywords (deployment) and (index) will be replaced by the configured deployment and instance index (i.e. 'prod-vault' and '3')"
     default: "(deployment)-(index)"
   vault.ha.domain:
     description: "The DNS domain name to advertise in HA configuration.  If unspecified, advertise_addr will not be set."
+  vault.ha.redirect_address:
+    description: "This is the address to advertise to other Vault servers in the cluster for client redirection"
+  vault.ha.cluster_address:
+    description: "This is the address to advertise to other Vault servers in the cluster for request forwarding."
+  vault.ha.disable_clustering:
+    description: "This controls whether clustering features (currently, request forwarding) are enabled"
+    default: "true"
 
   vault.disable_mlock:
     description: Disable mlock if you're crazy
@@ -55,8 +75,24 @@ properties:
     description: Datacenter for Consul
   vault.backend.consul.token:
     description: Access Token for Consul
-  vault.backend.consul.redirect_addr:
-    description: "This is the address to advertise to other Vault servers in the cluster for client redirection."
+  vault.backend.consul.check_timeout:
+    description: The check interval used to send health check information to consul.
+    default: "5s"
+  vault.backend.consul.max_parallel:
+    description: The maximum number of concurrent requests to Consul.
+    default: 128
+  vault.backend.consul.tls.skip_verify:
+    description: Indicates whether host verification should be disabled.
+    default: false
+  vault.backend.consul.tls.min_version:
+    description: Minimum TLS version to use
+    default: "tls12"
+  vault.backend.consul.tls.ca_certificate:
+    description: Contents of the PEM-encoded TLS CA certificate
+  vault.backend.consul.tls.certificate:
+    description: Contents of the PEM-encoded TLS server certificate
+  vault.backend.consul.tls.key:
+    description: Contents of the PEM-encoded TLS server private key
 
   #
   # Zookeeper backend

--- a/jobs/vault/templates/config/vault.conf.erb
+++ b/jobs/vault/templates/config/vault.conf.erb
@@ -1,7 +1,8 @@
-<% if p("vault.disable_mlock") == true %>disable_mlock = true<% end %>
-<% if p("vault.statsite_addr", "").empty? == false %>statsite_addr = <%= p("vault.statsite_addr") %><% end %>
-<% if p("vault.statsd_addr", "").empty? == false %>statsd_addr = <%= p("vault.statsd_addr") %><% end %>
 <%
+  telemetry_enabled = false
+  if p("vault.statsite_addr", "").empty? == false or p("vault.statsd_addr", "").empty? == false
+    telemetry_enabled = true
+  end
   tls = false
   schema = "http"
   if_p("vault.listener.tcp.tls.certificate", "") do |cert|
@@ -12,15 +13,41 @@
       end
     end
   end
-%>
-<%
-  advertise_addr=""
+  consul_tls = false
+  if_p("vault.backend.consul.tls.certificate", "") do |consul_cert|
+    if_p("vault.backend.consul.tls.key", "") do |consul_key|
+      if consul_cert != "" and consul_key != ""
+        consul_tls = true
+      end
+    end
+  end
+
+  redirect_addr = ""
+  cluster_addr = ""
+  advertise_addr = ""
+  disable_clustering = ""
   unless p("vault.ha.domain","").empty?
     hostname = p("vault.ha.name").gsub('(deployment)', spec.deployment.to_s)
                                  .gsub('(index)',      spec.index.to_s)
     advertise_addr = "advertise_addr = \"#{schema}://#{hostname}.#{p("vault.ha.domain")}:#{p("vault.listener.tcp.port")}\""
   end
+  if p("vault.ha.redirect_address", "").empty? == false
+    redirect_addr = "redirect_addr = \"#{p("vault.ha.redirect_address")}\""
+  end
+  if p("vault.ha.cluster_address", "").empty? == false
+    cluster_addr = "cluster_addr = \"#{p("vault.ha.cluster_address")}\""
+  end
+  if p("vault.ha.disable_clustering", "false") == true
+    disable_clustering = "disable_clustering = \"#{p("vault.ha.disable_clustering")}\""
+  end
 %>
+<% if telemetry_enabled %>
+telemetry {
+  <% if p("vault.statsite_addr", "").empty? == false %>statsite_addr = <%= p("vault.statsite_addr") %><% end %>
+  <% if p("vault.statsd_addr", "").empty? == false %>statsd_addr = <%= p("vault.statsd_addr") %><% end %>
+}
+<% end %>
+<% if p("vault.disable_mlock") == true %>disable_mlock = true<% end %>
 <% if p("vault.backend.use_consul", "false") == true %>
 backend "consul"{
   path = "<%= p("vault.backend.consul.path") %>"
@@ -28,14 +55,30 @@ backend "consul"{
   <% if p("vault.backend.consul.scheme", "").empty? == false %>scheme = "<%= p("vault.backend.consul.scheme") %>"<% end %>
   <% if p("vault.backend.consul.datacenter", "").empty? == false %>datacenter = "<%= p("vault.backend.consul.datacenter") %>"<% end %>
   <% if p("vault.backend.consul.token", "").empty? == false %>token = "<%= p("vault.backend.consul.token") %>"<% end %>
-  <% if p("vault.backend.consul.redirect_addr", "").empty? == false %>redirect_addr = "<%= p("vault.backend.consul.redirect_addr") %>"<% end %>
+  <% if p("vault.backend.consul.check_timeout", "").empty? == false %>check_timeout = "<%= p("vault.backend.consul.check_timeout") %>"<% end %>
+  max_parallel = "<%= p("vault.backend.consul.max_parallel") %>"
+  <% if consul_tls %>
+    <% if p("vault.backend.consul.tls.skip_verify", "false") == true %>
+    tls_skip_verify = "true"
+    <% end %>
+    <% if p("vault.backend.consul.tls.min_version", "").empty? == false %>tls_min_version = "<%= p("vault.backend.consul.tls.min_version") %>"<% end %>
+    tls_ca_file = "/var/vcap/jobs/vault/ssl/ca_certificate.pem"
+    tls_cert_file = "/var/vcap/jobs/vault/ssl/consul_certificate.pem"
+    tls_key_file  = "/var/vcap/jobs/vault/ssl/consul_key.pem"
+  <% end %>
   <%= advertise_addr %>
+  <%= redirect_addr %>
+  <%= cluster_addr %>
+  <%= disable_clustering %>
 }
 <% elsif p("vault.backend.use_zookeeper", "false") == true %>
 backend "zookeeper" {
   address = "<%= p("vault.backend.zookeeper.address") %>"
   path = "<%= p("vault.backend.zookeeper.path") %>"
   <%= advertise_addr %>
+  <%= redirect_addr %>
+  <%= cluster_addr %>
+  <%= disable_clustering %>
 }
 <% elsif p("vault.backend.use_file", "false") == true %>
 backend "file" {
@@ -50,6 +93,9 @@ backend "s3" {
   <% if p("vault.backend.s3.endpoint", "").empty? == false %>endpoint = "<%= p('vault.backend.s3.endpoint') %>"<% end %>
   <% if p("vault.backend.s3.session_token", "").empty? == false %>session_token = "<%= p('vault.backend.s3.session_token') %>"<% end %>
   <%= advertise_addr %>
+  <%= redirect_addr %>
+  <%= cluster_addr %>
+  <%= disable_clustering %>
 }
 <% else %>
 backend "inmem" {
@@ -60,4 +106,5 @@ listener "tcp" {
  <% if !tls %>tls_disable = 1<% end %>
  tls_cert_file = "/var/vcap/jobs/vault/ssl/certificate.pem"
  tls_key_file  = "/var/vcap/jobs/vault/ssl/key.pem"
+ tls_min_version = "<%= p("vault.listener.tcp.tls.min_version") %>"
 }

--- a/jobs/vault/templates/ssl/ca_certificate.pem
+++ b/jobs/vault/templates/ssl/ca_certificate.pem
@@ -1,0 +1,1 @@
+<% if_p("vault.backend.consul.tls.ca_certificate") do |s| %><%= s.strip %><% end %>

--- a/jobs/vault/templates/ssl/consul_certificate.pem
+++ b/jobs/vault/templates/ssl/consul_certificate.pem
@@ -1,0 +1,1 @@
+<% if_p("vault.backend.consul.tls.certificate") do |s| %><%= s.strip %><% end %>

--- a/jobs/vault/templates/ssl/consul_key.pem
+++ b/jobs/vault/templates/ssl/consul_key.pem
@@ -1,0 +1,1 @@
+<% if_p("vault.backend.consul.tls.key") do |s| %><%= s.strip %><% end %>


### PR DESCRIPTION
This PR adds ability to deploy vault by enabling mutual auth between vault and consul. It provides ability to do following configuration in deployment manifest:
1. Setup TLS parameters for consul backend
2. Setup TLS parameters for listener
3. Setup Vault to use client certificates to authenticate with consul
Consul bosh release has also been modified to support TLS for http apis as part of this [PR](https://github.com/cloudfoundry-community/consul-boshrelease/pull/31)
This PR also adds some missing HA parameters like:
1. redirect_address
2. cluster_address
And adds these to add supported HA backends.
