### PR TITLE
Fix the issue with wrong leader address being used

### DIFF
--- a/jobs/vault/templates/config/vault.conf.erb
+++ b/jobs/vault/templates/config/vault.conf.erb
@@ -33,6 +33,9 @@
   end
   if p("vault.ha.redirect_address", "").empty? == false
     redirect_addr = "redirect_addr = \"#{p("vault.ha.redirect_address")}\""
+  else
+    port = p("vault.listener.tcp.port")
+    redirect_addr = "redirect_addr = \"#{schema}://#{spec.address}:#{port}\""
   end
   if p("vault.ha.cluster_address", "").empty? == false
     cluster_addr = "cluster_addr = \"#{p("vault.ha.cluster_address")}\""


### PR DESCRIPTION
If vault and consul jobs are running on different nodes then we need to configure the consul backend with IP address of consul in its `address` field. In that case vault's leader address is shown as the address specified in consul backend's address field (you can see this by running `vault status` command). This is most probably a bug in vault itself. However, a workaround for this issue is to specify the correct `redirect_addr` in consul backend. As per vault documentation the `redirect_addr` should be set to each instance's ip address. This fix sets the redirec_addr, if not specified ,to instance ip address. This guarantees that the right address is shown as leader for vault.