### PR TITLE
Telemetry statsite and statsd settings have been fixed

### DIFF
--- a/jobs/vault/templates/config/vault.conf.erb
+++ b/jobs/vault/templates/config/vault.conf.erb
@@ -43,8 +43,8 @@
 %>
 <% if telemetry_enabled %>
 telemetry {
-  <% if p("vault.statsite_addr", "").empty? == false %>statsite_addr = <%= p("vault.statsite_addr") %><% end %>
-  <% if p("vault.statsd_addr", "").empty? == false %>statsd_addr = <%= p("vault.statsd_addr") %><% end %>
+  <% if p("vault.statsite_addr", "").empty? == false %>statsite_address = "<%= p("vault.statsite_addr") %>"<% end %>
+  <% if p("vault.statsd_addr", "").empty? == false %>statsd_address = "<%= p("vault.statsd_addr") %>"<% end %>
 }
 <% end %>
 <% if p("vault.disable_mlock") == true %>disable_mlock = true<% end %>


### PR DESCRIPTION
Hi Guys,

according to [Vault documentation](https://www.vaultproject.io/docs/config/index.html), statsd and statsfile settings should look as follow:
```
telemetry {
  statsite_address = "127.0.0.1:8125"
}
```

or:
```
telemetry {
  statsd_address  = "127.0.0.1:8125"
}
```

Before this PR, when telemetry has been configured in a manifest, Vault job was not able to start and it returns the following message in the log file:
```
Error loading configuration from /var/vcap/jobs/vault/config/server.hcl: At 5:22: expected: IDENT | STRING | ASSIG
N | LBRACE got: FLOAT
Error loading configuration from /var/vcap/jobs/vault/config/server.hcl: error parsing 'telemetry': 1 error(s) occ
urred:

* telemetry: invalid key 'statsd_addr' on line 5
```