### PR TITLE
Fix config error when specify vault.ha.cluster_addr:

### DIFF
--- a/jobs/vault/templates/config/vault.conf.erb
+++ b/jobs/vault/templates/config/vault.conf.erb
@@ -28,7 +28,7 @@
 
   cluster_port = p("vault.listener.cluster.port")
   cluster_addr = "cluster_addr = \"#{p("vault.ha.cluster_address",
-                                       "#{schema}://#{spec.ip}:#{cluster_port}\"")}"
+                                       "#{schema}://#{spec.ip}:#{cluster_port}")}\""
   disable_clustering = ""
   if p("vault.ha.disable_clustering", "false") == true
     disable_clustering = "disable_clustering = \"#{p("vault.ha.disable_clustering")}\""


### PR DESCRIPTION
- Fix error in generation of config file, missing end double quote " when specify cluster_addr
E.g. with cluster_addr=http://vault.exemple.com:8200, the server.hcl is generated with
`cluster_addr = "http://vault.exemple.com:8200/` without the end double quote.
And there are errors in /var/vcap/sys/log/vault/vault.log
`Error loading configuration from /var/vcap/jobs/vault/config/server.hcl: At 14:62: literal not terminated`