### PR TITLE
Fix the manifest file:

### DIFF
--- a/manifests/vault.yml
+++ b/manifests/vault.yml
@@ -11,9 +11,9 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry-community/consul-boshrelease?v=22.0.0
   sha1: 1f8ed4e78213580933fe4ac39de0ff03cd609eb2
 - name: vault
-  version: 0.4.3
-  url: https://bosh.io/d/github.com/cloudfoundry-community/vault-boshrelease?v=0.4.3
-  sha1: d9bd5d109ea060e3475f17e6f4beb78b91e980a8
+  version: 0.6.1
+  url: https://bosh.io/d/github.com/cloudfoundry-community/vault-boshrelease?v=0.6.1
+  sha1: 9f1bc371b5c1b7faadca97b892d6cc6d3c6baea6
 
 stemcells:
 - alias: trusty


### PR DESCRIPTION
The config changed. But the release is not updated.
E.g. vault.storage.use_consul is used to be vault.backend.use_consul in 0.4.2