### PR TITLE
Fixing Vault Advertising Environment Variable

### DIFF
--- a/jobs/vault-broker/templates/bin/ctl
+++ b/jobs/vault-broker/templates/bin/ctl
@@ -24,7 +24,7 @@ case $1 in
     export SERVICE_TAGS="<%= p('vault.broker.service.tags', []).join(', ') %>"
 
     export VAULT_ADDR="<%= p('vault.broker.backend.address') %>"
-    export VAULT_ADVERTISE="<%= p('vault.broker.backend.advertise') %>"
+    export VAULT_ADVERTISE_ADDR="<%= p('vault.broker.backend.advertise') %>"
     export VAULT_TOKEN="<%= p('vault.broker.backend.token') %>"
     export VAULT_SKIP_VERIFY="<%= p('vault.broker.backend.skip_verify', false) ? 'yes' : '' %>"
 


### PR DESCRIPTION
The Vault advertise address was set with wrong environment variable name. It was being set with `VAULT_ADVERTISE` but the vault-broker was looking for `VAULT_ADVERTISE_ADDR`.

It can be found here: https://github.com/cloudfoundry-community/vault-broker/blob/master/main.go#L357