### PR TITLE
bosh2 manifest contains cf-deployment defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ vault/9f34f839-92a0-4827-a713-c43a2430c0d9  running        z1  10.244.0.185
 Next you need to initialize the Vault. Connect via port `:8200`:
 
 ```
-export VAULT_ADDR=http://10.244.0.187:8200
+export VAULT_ADDR=https://10.244.0.187:8200
 export VAULT_SKIP_VERIFY=true
 vault init
 ```

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,10 @@
+## Breaking changes
+
+* `vault-broker` properties `vault.broker.username` and `vault.broker.password` have been renamed `username` and `password` respectively. This is to allow the job to be supported by the `broker-registrar-boshrelease`.
+
+## Updates
+
+* `manifests/vault.yml` has default `vm_type`, `persistent_disk_type` and `network` name that matches the `cloud-config` from `cf-deployment` project. See `manifests/operators/scale.yml` for an operator file to modify these values.
+* README has been updated to recommend the bosh2 manifests and operator files
+* `manifests/operators/servicebroker.yml` will add the `vault-broker` job in a new instance
+* `vault-broker` will attempt to discover vault cluster via local consul (`localhost:8500`) if explicit backend address not provided; this feature is used in the

--- a/jobs/vault-broker/spec
+++ b/jobs/vault-broker/spec
@@ -2,6 +2,7 @@
 name: vault-broker
 packages:
   - vault-broker
+  - jq
 templates:
   bin/ctl: bin/ctl
   bin/monit_debugger: bin/monit_debugger
@@ -9,15 +10,27 @@ templates:
   helpers/ctl_setup.sh: helpers/ctl_setup.sh
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
 
+provides:
+- name: servicebroker
+  type: servicebroker
+  properties:
+    - port
+    - username
+    - password
+
 properties:
   vault.broker.guid:
     description: A unique GUID to use for this service broker inside of Cloud Foundry.
     default: ''
 
-  vault.broker.username:
+  port:
+    description: Binding port for broker API
+    default: 5000
+
+  username:
     description: The username for authenticating interaction with Cloud Foundry.
     default: vault
-  vault.broker.password:
+  password:
     description: The password for authenticating interaction with Cloud Foundry.
     default: vault
 

--- a/jobs/vault-broker/templates/bin/ctl
+++ b/jobs/vault-broker/templates/bin/ctl
@@ -6,9 +6,6 @@ set -u # report the usage of uninitialized variables
 # Setup env vars and folders for the webapp_ctl script
 source /var/vcap/jobs/vault-broker/helpers/ctl_setup.sh 'vault-broker'
 
-export PORT=${PORT:-5000}
-export LANG=en_US.UTF-8
-
 case $1 in
 
   start)
@@ -16,14 +13,22 @@ case $1 in
 
     export BROKER_GUID="<%= p('vault.broker.guid') %>"
 
-    export AUTH_USERNAME="<%= p('vault.broker.username') %>"
-    export AUTH_PASSWORD="<%= p('vault.broker.password') %>"
+    export AUTH_USERNAME="<%= p('username') %>"
+    export AUTH_PASSWORD="<%= p('password') %>"
 
     export SERVICE_NAME="<%= p('vault.broker.service.name') %>"
     export SERVICE_DESC="<%= p('vault.broker.service.description') %>"
     export SERVICE_TAGS="<%= p('vault.broker.service.tags', []).join(', ') %>"
 
-    export VAULT_ADDR="<%= p('vault.broker.backend.address') %>"
+    export PORT=<%= p("port") %>
+
+    <% if_p('vault.broker.backend.address') do |address| %>
+    export VAULT_ADDR="<%= address %>"
+    <% end.else do %>
+      VAULT_IP=$(curl localhost:8500/v1/catalog/service/vault\?tag=active | jq -r ".[0].Address")
+      VAULT_PORT=$(curl localhost:8500/v1/catalog/service/vault\?tag=active | jq -r ".[0].ServicePort")
+      export VAULT_ADDR="https://${VAULT_IP}:${VAULT_PORT}"
+    <% end %>
     export VAULT_ADVERTISE_ADDR="<%= p('vault.broker.backend.advertise') %>"
     export VAULT_TOKEN="<%= p('vault.broker.backend.token') %>"
     export VAULT_SKIP_VERIFY="<%= p('vault.broker.backend.skip_verify', false) ? 'yes' : '' %>"

--- a/manifests/operators/dev.yml
+++ b/manifests/operators/dev.yml
@@ -1,0 +1,6 @@
+---
+- type: replace
+  path: /releases/name=vault
+  value:
+    name: vault
+    version: latest

--- a/manifests/operators/scale.yml
+++ b/manifests/operators/scale.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /instance_groups/name=vault/vm_type
+  value: ((vm-type))
+
+- type: replace
+  path: /instance_groups/name=vault/persistent_disk_type
+  value: ((persistent-disk-type))

--- a/manifests/operators/servicebroker.yml
+++ b/manifests/operators/servicebroker.yml
@@ -1,0 +1,87 @@
+---
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: broker
+    azs: [z1,z2,z3]
+    instances: 1
+    vm_type: default
+    stemcell: default
+    networks: [{name: default}]
+
+    jobs:
+    - name: consul
+      release: consul
+      consumes:
+        consul_servers: { from: consul_leaders }
+      properties:
+        consul: {server: false}
+    - name: vault-broker
+      release: vault
+      properties:
+        username: vault
+        password: ((vault-broker-password))
+        vault:
+          broker:
+            guid: ((vault-broker-guid))
+
+            service:
+              name:        vault
+              description: Your Very Own Vault of Secrets
+              tags: [vault, credentials, secure, key-value]
+
+            backend:
+              token: ((vault-token))
+              skip_verify: true
+
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: broker-registrar
+    instances: 1
+    azs: [z1]
+    lifecycle: errand
+    vm_type: default
+    stemcell: default
+    networks: [{name: default}]
+    jobs:
+    - name: broker-registrar
+      release: broker-registrar
+      properties:
+        servicebroker:
+          name: vault
+        cf:
+          api_url: ((cf-api-url))
+          username: ((cf-admin-username))
+          password: ((cf-admin-password))
+          skip_ssl_validation: ((cf-skip-ssl-validation))
+
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: broker-deregistrar
+    instances: 1
+    azs: [z1]
+    lifecycle: errand
+    vm_type: default
+    stemcell: default
+    networks: [{name: default}]
+    jobs:
+    - name: broker-deregistrar
+      release: broker-registrar
+      properties:
+        servicebroker:
+          name: vault
+        cf:
+          api_url: ((cf-api-url))
+          username: ((cf-admin-username))
+          password: ((cf-admin-password))
+          skip_ssl_validation: ((cf-skip-ssl-validation))
+
+- type: replace
+  path: /releases/-
+  value:
+    name: broker-registrar
+    version: 3.3.1
+    url: https://github.com/cloudfoundry-community/broker-registrar-boshrelease/releases/download/v3.3.1/broker-registrar-3.3.1.tgz
+    sha1: c95283460a4f962cee1cacabb7333774783a24e9

--- a/manifests/operators/step-down-token.yml
+++ b/manifests/operators/step-down-token.yml
@@ -1,0 +1,8 @@
+---
+- type: replace
+  path: /instance_groups/name=vault/jobs/name=vault/properties/vault/update?/step_down_token
+  value: ((vault-step-down-token))
+
+- type: replace
+  path: /instance_groups/name=vault/jobs/name=vault/properties/vault/update?/unseal_keys
+  value: ((vault-unseal-keys))

--- a/manifests/vault.yml
+++ b/manifests/vault.yml
@@ -51,6 +51,12 @@ variables:
   options:
     ca: vault-ca
     common_name: vault
+    extended_key_usage:
+    - client_auth
+    - server_auth
+    alternative_names:
+    - 127.0.0.1
+    - "*.vault.default.vault.bosh"
 
 stemcells:
 - alias: trusty


### PR DESCRIPTION
README updated to use bosh2 & bosh2 manifest

* [x] base manifest deploys 3-node vault/consul/certs
* [x] step-down-token.yml operator file and instructions
* [x] vault-broker operator file (`servicebroker.yml`)
* [x] vault-broker look up vault via consul
* [x] `bosh run-errand broker-registrar`
