### PR TITLE
DNS Support for HA

### DIFF
--- a/jobs/vault/templates/config/vault.conf.erb
+++ b/jobs/vault/templates/config/vault.conf.erb
@@ -23,12 +23,23 @@
   end
 
   port = p("vault.listener.tcp.port")
-  redirect_addr = "redirect_addr = \"#{p("vault.ha.redirect_address",
-                                         "#{schema}://#{spec.ip}:#{port}")}\""
+
+  # Check configuration for redirect_address property and replace (index) if present, this allows for simplified HA
+  # deployments where each node needs a unique address.
+  redirect_address = p("vault.ha.redirect_address", "").gsub('(index)', spec.index.to_s)
+
+  # if redirect_address is set use that, otherwise use the ip and port
+  redirect_addr = "redirect_addr = \"#{redirect_address.blank? ? "#{schema}://#{spec.ip}:#{port}" : redirect_address }\""
 
   cluster_port = p("vault.listener.cluster.port")
-  cluster_addr = "cluster_addr = \"#{p("vault.ha.cluster_address",
-                                       "#{schema}://#{spec.ip}:#{cluster_port}")}\""
+
+  # Check configuration for cluster_address property and replace (index) if present, this allows for simplified HA
+  # deployments where each node needs a unique address.
+  cluster_address = p("vault.ha.cluster_address", "").gsub('(index)', spec.index.to_s)
+
+  # if cluster_address is set use that, otherwise use the ip and cluster_port
+  cluster_addr = "cluster_addr = \"#{cluster_address.blank? ? "#{schema}://#{spec.ip}:#{cluster_port}" : cluster_address}\""
+
   disable_clustering = ""
   if p("vault.ha.disable_clustering", "false") == true
     disable_clustering = "disable_clustering = \"#{p("vault.ha.disable_clustering")}\""


### PR DESCRIPTION
Thanks for this bosh release. We were previously using version `0.4.3` and specifying something like this in our manifest:

```
  vault:
    ha:
      domain: bob.io
      name: vault-dev-(index)
``` 
This resulted in the vault config value being something like this on our first HA node:

```
advertised_addr: vault-dev-0.bob.io
```
This worked great, especially since we were using TLS and star certs for `bob.io`

When we updated to the latest bosh release things seemed to go fine. However there was a silent error waiting for us. Technically vault was functioning and passing health checks, however when actual HA mode kicked in and requests were forwarded to the leader the TLS handshake failed because our certs were for the wildcard domain `bob.io` not the IP addresses of the nodes. We realized our old manifest settings were now being completely ignored and our vault config was being written as:

```
redirect_addr: https://111.111.111.111
```
So we explicitly set the following in our manifest:

```
redirect_address: vault-dev-(index).bob.io
cluster_address: vault-dev-(index).bob.io
```
Only to realize that `(index)` replacement was removed and now vault was specifying:

```
redirect_addr: vault-dev-(index).bob.io
redirect_addr: vault-dev-(index).bob.io
```
This PR adds back in logic which allows us to specify enumerable DNS names and have functional HA mode. Without this change anyone in a similar situation would have to  generate TLS certificates with Domain name and IP SANs; which is impractical if using a real CA, dynamic IP addresses, etc. 
