### PR TITLE
Add operators and make consul more secure by default

### DIFF
--- a/manifests/operators/azs.yml
+++ b/manifests/operators/azs.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=vault/azs
+  value: ((azs))

--- a/manifests/operators/network.yml
+++ b/manifests/operators/network.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=vault/networks
+  value: [{name: ((network))}]

--- a/manifests/operators/s3.yml
+++ b/manifests/operators/s3.yml
@@ -1,0 +1,19 @@
+---
+- type: remove
+  path: /instance_groups/name=vault/jobs/name=consul
+- type: remove
+  path: /releases/name=consul
+- type: replace
+  path: /instance_groups/name=vault/jobs/name=vault/properties/vault/storage
+  value:
+    use_s3: true
+- type: replace
+  path: /instance_groups/name=vault/jobs/name=vault/properties/vault/storage?/s3?
+  value:
+     access_key: ((s3_access_key))
+     bucket: ((s3_bucket))
+     region: ((s3_region))
+     secret_key: ((s3_secret_key))
+- type: replace
+  path: /instance_groups/name=vault/instances
+  value: 1

--- a/manifests/operators/vm_type.yml
+++ b/manifests/operators/vm_type.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=vault/vm_type
+  value: ((vm_type))

--- a/manifests/vault.yml
+++ b/manifests/vault.yml
@@ -21,7 +21,8 @@ instance_groups:
       consul_servers: { as: consul_leaders }
     consumes:
       consul_servers: { from: consul_leaders }
-
+    properties:
+      encrypt: ((consul-encrypt-key))
   - name: vault
     release: vault
     properties:
@@ -41,6 +42,8 @@ update:
   update_watch_time: 1000-60000
 
 variables:
+- name: consul-encrypt-key
+  type: password
 - name: vault-ca
   type: certificate
   options:


### PR DESCRIPTION
Added some operators for different tasks, most notably switching the backend to s3. Also changed the default for consul deployments to use an encryption key.