### PR TITLE
Allow to use custom storage types

### DIFF
--- a/jobs/vault/spec
+++ b/jobs/vault/spec
@@ -135,3 +135,15 @@ properties:
     description: AWS S3 endpoint
   vault.storage.s3.session_token:
     description: AWS session token
+
+  #
+  # Custom storage
+  #
+  vault.storage.custom.type:
+    description: Type of custom storage
+    example: zookeeper
+  vault.storage.custom.options:
+    description: Config options for storage type
+    example: |
+      address: localhost:2181
+      path: vault/

--- a/jobs/vault/templates/config/vault.conf.erb
+++ b/jobs/vault/templates/config/vault.conf.erb
@@ -91,8 +91,14 @@ storage "s3" {
   <%= cluster_addr %>
   <%= disable_clustering %>
 }
-<% else %>
+<% elsif p("vault.storage.use_inmem", "false") == true %>
 storage "inmem" {
+}
+<% else %>
+storage "<%= p("vault.storage.custom.type") %>" {
+<% p("vault.storage.custom.options").to_a.each do | k, v | %>
+  <%= k %> = "<%= v %>"
+<% end %>
 }
 <% end %>
 listener "tcp" {


### PR DESCRIPTION
Usage example:
```
properties:
  vault:
    storage:
      custom:
        type: zookeeper
        options:
          address: localhost:2181
          path: vault/
```