### PR TITLE
add MySQL storage support

### DIFF
--- a/jobs/vault/spec
+++ b/jobs/vault/spec
@@ -16,6 +16,7 @@ templates:
   ssl/consul_ca_certificate.pem: ssl/consul_ca_certificate.pem
   ssl/consul_certificate.pem: ssl/consul_certificate.pem
   ssl/consul_key.pem: ssl/consul_key.pem
+  ssl/mysql_ca_certificate.pem: ssl/mysql_ca_certificate.pem
 properties:
   vault.listener.tcp.address:
     description: Address for TCP connection
@@ -135,3 +136,25 @@ properties:
     description: AWS S3 endpoint
   vault.storage.s3.session_token:
     description: AWS session token
+
+  #
+  # MySQL storage
+  #
+  vault.storage.use_mysql:
+    description: Use MySQL storage
+    default: false
+  vault.storage.mysql.address:
+    description: Specifies the address of the MySQL host (eg. "127.0.0.1:3306")
+  vault.storage.mysql.username:
+    description: Specifies the MySQL username to connect to the database.
+  vault.storage.mysql.password:
+    description: Specifies the MySQL password to connect to the database.
+  vault.storage.mysql.database:
+    description: Specifies the name of the database. If the database does not exist, Vault will attempt to create it.
+  vault.storage.mysql.table:
+    description: Specifies the name of the table. If the table does not exist, Vault will attempt to create it.
+  vault.storage.mysql.tls.ca_certificate:
+    description: Specifies the CA certificate to connect using TLS.
+  vault.storage.mysql.max_parallel:
+    description: Specifies the maximum number of concurrent requests to MySQL.
+    default: 128

--- a/jobs/vault/templates/config/vault.conf.erb
+++ b/jobs/vault/templates/config/vault.conf.erb
@@ -91,6 +91,17 @@ storage "s3" {
   <%= cluster_addr %>
   <%= disable_clustering %>
 }
+<% elsif p("vault.storage.use_mysql", "false") == true %>
+storage "mysql" {
+  address = "<%= p('vault.storage.mysql.address') %>"
+  database = "<%= p('vault.storage.mysql.database') %>"
+  table = "<%= p('vault.storage.mysql.table') %>"
+  username = "<%= p('vault.storage.mysql.username') %>"
+  password = "<%= p('vault.storage.mysql.password') %>"
+  max_parallel = "<%= p('vault.storage.mysql.max_parallel') %>"
+
+  <% if p("value.storage.mysql.tls.ca_certificate", "").empty? == false %>tls_ca_file = "/var/vcap/jobs/vault/ssl/mysql_ca_certificate.pem"<% end %>
+}
 <% else %>
 storage "inmem" {
 }

--- a/jobs/vault/templates/ssl/mysql_ca_certificate.pem
+++ b/jobs/vault/templates/ssl/mysql_ca_certificate.pem
@@ -1,0 +1,1 @@
+<% if_p("vault.storage.mysql.tls.ca_certificate") do |s| %><%= s.strip %><% end %>


### PR DESCRIPTION
This PR adds an option to use MySQL as a storage backend in Vault.