### PR TITLE
Fix path for persistent_disk_type

### DIFF
--- a/manifests/operators/scale.yml
+++ b/manifests/operators/scale.yml
@@ -4,5 +4,5 @@
   value: ((vm-type))
 
 - type: replace
-  path: /instance_groups/name=vault/persistent_disk_type
+  path: /instance_groups/name=vault/persistent_disk_type?
   value: ((persistent-disk-type))


### PR DESCRIPTION
I tried to deploy with `manifests/vault.yml`
```bash
$ bosh -e my-env deploy -d vault ./manifests/vault.yml \
    --vars-store ./credentials/creds.yml \
.
.
   -o ../vault-boshrelease/manifests/operators/scale.yml \
   -v vm-type=large \
   -v persistent-disk-type=large \
.
.
```
But, an error occurred.
```
Evaluating manifest:
  Expected to find a map key 'pesistent_disk_type' for path '/instance_groups/name=vault/pesistent_disk_type' (found map keys: 'azs', 'instances', 'jobs', 'name', 'networks', 'persistent_disk', 'stemcell', 'vm_type')

Exit code 1
```
So I fixed the path.