### PR TITLE
Minor changes to 1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ Vault instance before starting Vault:
   - `/var/vcap/jobs/vault/tls/other_tls_cert/cert.pem`
   - `/var/vcap/jobs/vault/tls/other_tls_cert/key.pem`
 
+**WARNING** Prior to 1.0.0 release, the `VAULT_SKIP_VERIFY` environment variable is set
+if the vault address contains `https`, so connecting to
+the vault server on 127.0.0.1 (during unseal) would not throw an SSL exception. With 1.0.0
+release, the environmental variable is no longer  set  by default. The proper solution is 
+to include SAN entry of `127.0.0.1` in the vault certs.
 
 Zero Downtime Updates
 ---------------------

--- a/README.md
+++ b/README.md
@@ -160,15 +160,27 @@ Vault instance before starting Vault:
   - `/var/vcap/jobs/vault/tls/other_tls_cert/cert.pem`
   - `/var/vcap/jobs/vault/tls/other_tls_cert/key.pem`
 
-**WARNING** Prior to 1.0.0 release, the `VAULT_SKIP_VERIFY` environment variable is set
+### Monit Script Configuration
+
+In order to enable features like zero downtime redeploys this Bosh release 
+bundles scripts that utilize the Vault CLI. Manifest properties are available to 
+explicitly set the value of the `VAULT_SKIP_VERIFY` and `VAULT_ADDR` 
+environment variables in the context of these monit scripts:
+```yaml
+  properties:
+    vault:
+      tls_skip_verify: false                      #default if absent
+      addr:            "https://127.0.0.1:8200"   #default if absent
+```
+Prior to 1.0.0 release, the `VAULT_SKIP_VERIFY` environment variable is set
 if the vault address contains `https`, so connecting to
 the vault server on 127.0.0.1 (during unseal) would not throw an SSL exception. Since 1.0.0
 release, the environmental variable is no longer  set  by default. There are several possible
 ways to address the situation.
 - If you have **only one** vault node, you can use `properties.vault.addr` to set
-  `VAULT_ADDR` environmental variable.
+  `VAULT_ADDR` environmental variable according to your cert CN.
 - If you have more than one nodes, **and** can use SAN IP entry of `127.0.0.1` in your certs, leave out
-  `properties.vault.addr` (defaults to `https://127.0.0.1:8200`).
+  `properties.vault.addr` (using the default).
 - If you have more than one nodes, and can _NOT_ use SAN IP entry of `127.0.0.1` in your certs, you 
   need to specify `properties.vault.skip_verify`, and leave out `properties.vault.addr`. This breaks
   the [security model](https://www.vaultproject.io/docs/commands/index.html#vault_skip_verify), though

--- a/README.md
+++ b/README.md
@@ -162,9 +162,17 @@ Vault instance before starting Vault:
 
 **WARNING** Prior to 1.0.0 release, the `VAULT_SKIP_VERIFY` environment variable is set
 if the vault address contains `https`, so connecting to
-the vault server on 127.0.0.1 (during unseal) would not throw an SSL exception. With 1.0.0
-release, the environmental variable is no longer  set  by default. The proper solution is 
-to include SAN entry of `127.0.0.1` in the vault certs.
+the vault server on 127.0.0.1 (during unseal) would not throw an SSL exception. Since 1.0.0
+release, the environmental variable is no longer  set  by default. There are several possible
+ways to address the situation.
+- If you have **only one** vault node, you can use `properties.vault.addr` to set
+  `VAULT_ADDR` environmental variable.
+- If you have more than one nodes, **and** can use SAN IP entry of `127.0.0.1` in your certs, leave out
+  `properties.vault.addr` (defaults to `https://127.0.0.1:8200`).
+- If you have more than one nodes, and can _NOT_ use SAN IP entry of `127.0.0.1` in your certs, you 
+  need to specify `properties.vault.skip_verify`, and leave out `properties.vault.addr`. This breaks
+  the [security model](https://www.vaultproject.io/docs/commands/index.html#vault_skip_verify), though
+  minor since the communication is at the local host.
 
 Zero Downtime Updates
 ---------------------

--- a/jobs/vault/spec
+++ b/jobs/vault/spec
@@ -14,6 +14,14 @@ templates:
   config/vault.conf.erb:  config/server.hcl
   tls/certs.ttar: tls/certs.ttar
 properties:
+  vault.skip_verify:
+    description: Do not verify Vault's presented certificate before communicating with it. Set in the environment when monit scripts run the Vault CLI
+    default: false
+
+  vault.addr:
+    description: Address of the Vault server expressed as a URL and port. Set in the environment when monit scripts run the Vault CLI
+    default: https://127.0.0.1:8200
+
   vault.config:
     description: HCL string literal representing the full Vault configuration, will take precedence over any other configuration properties
 

--- a/jobs/vault/templates/bin/post-start
+++ b/jobs/vault/templates/bin/post-start
@@ -6,6 +6,7 @@ if [[ "$(cat "${JOB_DIR}/data/unseal_keys" | wc -l)" -gt 2 ]]; then
   cat "${JOB_DIR}/data/unseal_keys" | \
     while read key
     do
-      vault unseal ${key}
+      key=$(echo "$key" | tr -d '[:space:]')
+      [[ -n "$key" ]] && vault unseal ${key} || echo "skip empty key"
     done
 fi

--- a/jobs/vault/templates/data/properties.sh.erb
+++ b/jobs/vault/templates/data/properties.sh.erb
@@ -10,7 +10,7 @@ export JOB_INDEX=<%= index %>
 export JOB_FULL="$NAME/$JOB_INDEX"
 
 <%
-vault_addr=p("vault.addr", "127.0.0.1")
+vault_addr=p("vault.addr", "https://127.0.0.1:8200")
 tls_skip_verify=p("vault.skip_verify", "false")
 %>
 export VAULT_ADDR="<%= vault_addr %>"

--- a/jobs/vault/templates/data/properties.sh.erb
+++ b/jobs/vault/templates/data/properties.sh.erb
@@ -10,10 +10,11 @@ export JOB_INDEX=<%= index %>
 export JOB_FULL="$NAME/$JOB_INDEX"
 
 <%
-vault_addr=p("vault.address", "")
+vault_addr=p("vault.addr", "127.0.0.1")
+tls_skip_verify=p("vault.skip_verify", "false")
 %>
 export VAULT_ADDR="<%= vault_addr %>"
 export VAULT_TOKEN="<%= p("vault.update.step_down_token","") %>"
-<% if vault_addr.include? "https" %>
+<% if tls_skip_verify.to_s == "true" %>
 export VAULT_SKIP_VERIFY=1
 <% end %>


### PR DESCRIPTION
- Update Readme on vault cert need of SAN IP entries for unseal
- Update post-start script, so empty line in unseal keys won't cause unseal to fail.
