### PR TITLE
Fixes #62 Include CA in sample manifest

### DIFF
--- a/manifests/vault.yml
+++ b/manifests/vault.yml
@@ -32,7 +32,7 @@ instance_groups:
           }
       tls:
         - name: vault
-          cert: ((vault-tls.certificate))
+          cert: ((vault-tls.certificate))((vault-ca.certificate))
           key: ((vault-tls.private_key))
 update:
   canaries: 1


### PR DESCRIPTION
Fix https://github.com/cloudfoundry-community/vault-boshrelease/issues/62 by appending the generated CA certificate to the TLS certificate in manifest/vault.yml