### PR TITLE
Fix post start script to use vault 1.1

### DIFF
--- a/jobs/vault/templates/bin/post-start
+++ b/jobs/vault/templates/bin/post-start
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-source /var/vcap/jobs/vault/helpers/ctl_setup.sh 'vault'
+set -x
+
+source /var/vcap/jobs/vault/data/properties.sh
+JOB_DIR=/var/vcap/jobs/vault
 
 if [[ "$(cat "${JOB_DIR}/data/unseal_keys" | wc -l)" -gt 2 ]]; then
   cat "${JOB_DIR}/data/unseal_keys" | \
     while read key
     do
       key=$(echo "$key" | tr -d '[:space:]')
-      [[ -n "$key" ]] && vault unseal ${key} || echo "skip empty key"
+      [[ -n "$key" ]] && /var/vcap/packages/vault/bin/vault operator unseal ${key}  || echo "skip empty key"
     done
 fi


### PR DESCRIPTION
Signed-off-by: Joe Goller <joe.goller@aon.com>

We had to change the post start script so that it unseal the vault server successfully.
We removed unnecessary dependencies with the setup_ctl and added debug logging to the script.'