### PR TITLE
Support dynamic networks

### DIFF
--- a/jobs/vault/templates/config/vault.conf.erb
+++ b/jobs/vault/templates/config/vault.conf.erb
@@ -2,7 +2,7 @@
   # If the Vault config was passed in use it as is and exit
   if_p("vault.config") do |vault_config|
     vault_config.gsub!('(index)', spec.index.to_s)
-    vault_config.gsub!('(ip)', spec.ip)
+    vault_config.gsub!('(ip)', spec.ip) unless spec.ip.nil?
 %>
     <%= vault_config %>
 <% end %>

--- a/jobs/vault/templates/data/properties.sh.erb
+++ b/jobs/vault/templates/data/properties.sh.erb
@@ -12,7 +12,7 @@ export JOB_FULL="$NAME/$JOB_INDEX"
 <%
 vault_addr=p("vault.addr", "https://127.0.0.1:8200")
 vault_addr.gsub!('(index)', spec.index.to_s)
-vault_addr.gsub!('(ip)', spec.ip)
+vault_addr.gsub!('(ip)', spec.ip) unless spec.ip.nil?
 
 tls_skip_verify=p("vault.skip_verify", "false")
 %>


### PR DESCRIPTION
BOSH supports [dynamic networks](https://bosh.io/docs/networks/#dynamic), when using a dynamic network `spec.ip` is nil, which causes manifest templating to fail in the following places:

- https://github.com/cloudfoundry-community/vault-boshrelease/blob/master/jobs/vault/templates/data/properties.sh.erb#L15
- https://github.com/cloudfoundry-community/vault-boshrelease/blob/master/jobs/vault/templates/config/vault.conf.erb#L5

When running Vault in HA mode, it is not necessary for Vault to know about other instances, hence dynamic networks can be used, which simplify the deployment.

I have successfully deployed Vault with this change.