### PR TITLE
Fix TLS property example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,18 +137,17 @@ certificates:
 
 ```yaml
 properties:
-  vault:
-    tls:
-      - name: "my_tls_cert"
-        cert: |
-          -----BEGIN CERTIFICATE-----
-          CertBlockAsRawText
-          -----END CERTIFICATE-----
-        key: ((or_use_a_variable))
+  tls:
+    - name: "my_tls_cert"
+      cert: |
+        -----BEGIN CERTIFICATE-----
+        CertBlockAsRawText
+        -----END CERTIFICATE-----
+      key: ((or_use_a_variable))
 
-      - name: "other_tls_cert"
-        cert: ((other_tls_certificate_content))
-        key: ((other_tls_key_content))
+    - name: "other_tls_cert"
+      cert: ((other_tls_certificate_content))
+      key: ((other_tls_key_content))
 ```
 
 The above configuration will create the following files on the


### PR DESCRIPTION
`tls` property is not under "vault" key, copying the current example in the readme will cause Vault to come up without any TLS configuration